### PR TITLE
`consistent-function-scoping`: Ignore anything containing JSX

### DIFF
--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -125,7 +125,7 @@ const create = context => {
 	const {scopeManager} = sourceCode;
 
 	const reports = [];
-	let jsx = false;
+	let hasJsx = false;
 
 	return {
 		ArrowFunctionExpression: node => {

--- a/rules/consistent-function-scoping.js
+++ b/rules/consistent-function-scoping.js
@@ -30,9 +30,6 @@ function checkReferences(scope, parent, scopeManager) {
 		}
 
 		const hitDefinitions = variable.defs.some(definition => {
-			console.log('CCC.2', {
-				definition,
-			});
 			const scope = scopeManager.acquire(definition.node);
 			return parent === scope;
 		});
@@ -155,16 +152,16 @@ const create = context => {
 		JSXElement: () => {
 			// Turn off this rule if we see a JSX element because scope
 			// references does not include JSXElement nodes.
-			jsx = true;
+			hasJsx = true;
 		},
 		':matches(ArrowFunctionExpression, FunctionDeclaration):exit': () => {
 			const report = reports.pop();
-			if (report && !jsx) {
+			if (report && !hasJsx) {
 				context.report(report);
 			}
 
 			if (reports.length === 0) {
-				jsx = false;
+				hasJsx = false;
 			}
 		}
 	};

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -144,6 +144,18 @@ ruleTester.run('consistent-function-scoping', rule, {
 				}
 				return foo;
 			}
+		`,
+		outdent`
+			function doFoo(foo) {
+				function doBar(bar) {
+					foo.bar = bar;
+				}
+				function doZaz(zaz) {
+					doBar(zaz);
+				}
+
+				doZaz('zaz');
+			};
 		`
 	],
 	invalid: [

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -180,6 +180,14 @@ ruleTester.run('consistent-function-scoping', rule, {
 				}
 				return Bar;
 			};
+		`,
+		outdent`
+			function doFoo(Foo) {
+				function doBar() {
+					return new Foo();
+				}
+				return doBar;
+			};
 		`
 	],
 	invalid: [

--- a/test/consistent-function-scoping.js
+++ b/test/consistent-function-scoping.js
@@ -6,6 +6,12 @@ import rule from '../rules/consistent-function-scoping';
 const ruleTester = avaRuleTester(test, {
 	env: {
 		es6: true
+	},
+	parserOptions: {
+		ecmaVersion: 2018,
+		ecmaFeatures: {
+			jsx: true
+		}
 	}
 });
 
@@ -155,6 +161,24 @@ ruleTester.run('consistent-function-scoping', rule, {
 				}
 
 				doZaz('zaz');
+			};
+		`,
+		outdent`
+			function doFoo() {
+				return function doBar() {};
+			}
+		`,
+		outdent`
+			function doFoo(FooComponent) {
+				return <FooComponent />;
+			}
+		`,
+		outdent`
+			function doFoo(FooComponent) {
+				function Bar() {
+					return <FooComponent />;
+				}
+				return Bar;
 			};
 		`
 	],


### PR DESCRIPTION
Fixes #376.
Depends on #378.

I could not find a quick way to include JSX elements in the reference detection. It looks like the scope utilities don't recognize JSX.

We can circle back around to this later but I wanted to get the bugs cleared out first.